### PR TITLE
cxi: adjust cxip_addr stack variable init

### DIFF
--- a/prov/cxi/src/cxip_av.c
+++ b/prov/cxi/src/cxip_av.c
@@ -85,10 +85,10 @@ static int cxip_av_insert_addr(struct cxip_av *av, struct cxip_addr *addr,
 {
 	struct cxip_av_entry *entry;
 	struct cxip_av_auth_key_entry *auth_key_entry = NULL;
-	struct cxip_addr auth_key_addr = {
-		.nic = addr->nic,
-		.pid = addr->pid
-	};
+	struct cxip_addr auth_key_addr = {};
+	auth_key_addr.nic = addr->nic;
+	auth_key_addr.pid = addr->pid;
+	auth_key_addr.vni = 0;
 
 	if (flags & FI_AUTH_KEY) {
 		auth_key_entry =


### PR DESCRIPTION
Avoids issue encounterd when switching compilers.